### PR TITLE
fg_guts: replace html_nodes by html_node and locate table by xpath immediately

### DIFF
--- a/R/fg_guts.R
+++ b/R/fg_guts.R
@@ -10,12 +10,9 @@
 # wOBA and FIP coefficients and constants
 
 fg_guts <- function() {
-  guts_table <- read_html("http://www.fangraphs.com/guts.aspx?type=cn")
-  guts_table <- guts_table %>% html_nodes(xpath = '//*[@id="content"]/table') %>% html_table(fill = TRUE)
-  guts_table<- as.data.frame(guts_table)[-(1:2), (1:14)]
-  names(guts_table) <- c("season", "lg_woba", "woba_scale", "wBB", "wHBP", "w1B", "w2B", "w3B", "wHR", "runSB", "runCS", "lg_r_pa", "lg_r_w", "cFIP")
-  for(i in c(2:ncol(guts_table))) {
-    guts_table[,i] <- as.numeric(as.character(guts_table[,i]))
-  }
-  guts_table
+  read_html("http://www.fangraphs.com/guts.aspx?type=cn") %>% 
+    html_node(xpath = '//*[(@id = "GutsBoard1_dg1_ctl00")]') %>% 
+    html_table %>% 
+    setNames(c("season", "lg_woba", "woba_scale", "wBB", "wHBP", "w1B", "w2B", 
+               "w3B", "wHR", "runSB", "runCS", "lg_r_pa", "lg_r_w", "cFIP"))
 }

--- a/R/fg_park.R
+++ b/R/fg_park.R
@@ -8,12 +8,10 @@
 #' fg_park(2013)
 
 fg_park <- function(yr) {
-  factor_table <- read_html(paste0("http://www.fangraphs.com/guts.aspx?type=pf&teamid=0&season=", yr))
-  factor_table <- factor_table %>% html_nodes(xpath = '//*[@id="content"]/table') %>% html_table(fill = TRUE)
-  factor_table <- as.data.frame(factor_table)[-(1:4), (1:14)]
-  names(factor_table) <- c("season", "home_team", "basic", "single", "double", "triple", "hr", "so", "UIBB", "GB", "FB", "LD", "IFFB", "FIP")
-  for(i in c(3:14)) {
-    factor_table[,i] <- as.numeric(as.character(factor_table[,i]))
-  }
-  factor_table
+  read_html(paste0("http://www.fangraphs.com/guts.aspx?type=pf&teamid=0&season=", yr)) %>% 
+    html_node(xpath = '//*[(@id = "GutsBoard1_dg1_ctl00")]') %>% 
+    html_table %>% 
+    setNames(c("season", "home_team", "basic", "single", "double", "triple", "hr", 
+               "so", "UIBB", "GB", "FB", "LD", "IFFB", "FIP"))
+  
 }

--- a/R/fg_park_hand.R
+++ b/R/fg_park_hand.R
@@ -8,7 +8,7 @@
 #' fg_park_hand(2013)
 
 fg_park_hand <- function(yr) {
-  read_html(paste0("http://www.fangraphs.com/guts.aspx?type=pfh&teamid=0&season=", 2013)) %>%
+  read_html(paste0("http://www.fangraphs.com/guts.aspx?type=pfh&teamid=0&season=", yr)) %>%
     html_node(xpath = '//*[(@id = "GutsBoard1_dg1_ctl00")]') %>% 
     html_table %>% 
     setNames(c("season", "home_team", "single_as_LHH", "single_as_RHH", 

--- a/R/fg_park_hand.R
+++ b/R/fg_park_hand.R
@@ -8,12 +8,10 @@
 #' fg_park_hand(2013)
 
 fg_park_hand <- function(yr) {
-  factor_table <- read_html(paste0("http://www.fangraphs.com/guts.aspx?type=pfh&teamid=0&season=", yr))
-  factor_table <- factor_table %>% html_nodes(xpath = '//*[@id="content"]/table') %>% html_table(fill = TRUE)
-  factor_table <- as.data.frame(factor_table)[-(1:4), (1:10)]
-  names(factor_table) <- c("season", "home_team", "single_as_LHH", "single_as_RHH", "double_as_LHH", "double_as_RHH", "triple_as_LHH", "triple_as_RHH", "hr_as_LHH", "hr_as_RHH")
-  for(i in c(3:10)) {
-    factor_table[,i] <- as.numeric(as.character(factor_table[,i]))
-  }
-  factor_table
+  read_html(paste0("http://www.fangraphs.com/guts.aspx?type=pfh&teamid=0&season=", 2013)) %>%
+    html_node(xpath = '//*[(@id = "GutsBoard1_dg1_ctl00")]') %>% 
+    html_table %>% 
+    setNames(c("season", "home_team", "single_as_LHH", "single_as_RHH", 
+               "double_as_LHH", "double_as_RHH", "triple_as_LHH", "triple_as_RHH", 
+               "hr_as_LHH", "hr_as_RHH"))
 }


### PR DESCRIPTION
By using `'//*[(@id = "GutsBoard1_dg1_ctl00")]'` instead of `'//*[@id="content"]/table'` as xpath you can immediately locate the table within the http://www.fangraphs.com/guts.aspx web page. Moreover, calling `html_table` after using `html_node` (instead of `html_nodes`) doesn't return a `list` but rather a `data.frame`. Hence, you don't need

* `fill = TRUE` inside of `html_table`
* to convert the list using as.data.frame(.) explicitly
* to select columns by position [-(1:2), (1:14)]
* the for loop to convert columns to numeric

This can be used for the functions `fg_guts`, `fg_park`, and `fg_park_hand`.