### PR TITLE
Generalize standings_on_date_bref for arbitrary dates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Depends:
     R (>= 3.2.0)
 Imports:
     dplyr,
+    lubridate,
     pitchRx,
     reldist,
     rvest,


### PR DESCRIPTION
According to `readme.md` the function `standings_on_date_bref` "works as far as back as 1994, which is when both leagues split into three divisions."

I modified the function to allow for arbitrary dates as input. The main changes are:
* There is no more look up table, as table names are now retrieved from the html document
* You may pass multiple divisions, now. The function returns a named list. 
* There is a new parameter `from = FALSE` to switch between standings up to and including the date and standings for games played after the date
* Parameters y, m, and d are condensed into a single date parameter. 
* There is a check for the validity of the division names, but this check does not consider the date. 