### PR TITLE
Adding complete name for the lists/tables from standings function

### DIFF
--- a/R/standings_on_date_bref.R
+++ b/R/standings_on_date_bref.R
@@ -17,7 +17,7 @@
 #' standings_on_date_bref("2015-08-04", "AL East")
 #' }
 
-standings_on_date_bref <- function (date, division, from = FALSE) {
+standings_on_date_bref <- function(date, division, from = FALSE) {
 
   stopifnot(intersect(grepl("AL|NL", division), grepl("East|Central|West|Overall",
                                                       division)))
@@ -36,18 +36,21 @@ standings_on_date_bref <- function (date, division, from = FALSE) {
   #table_names <- html_doc %>% rvest::html_nodes(".section_heading") %>% rvest::html_text() %>% gsub(pattern = "\\s+", replacement = " ") %>% gsub(pattern = " Division", replacement = "") %>% trimws(which = c("left")) %>% trimws(which = c("right")) %>% .[1:16]
 
   table_names <- c("NL Overall", "AL Overall", "NL West" , "NL Central", "NL East", "AL West", "AL Central", "AL East", "NL Overall", "AL Overall", "NL West" , "NL Central", "NL East", "AL West", "AL Central", "AL East")
-
+  table_names[1:8] <- paste0(table_names[1:8], "_after_", date)     # Customizing list names for "After this Date" case
+  table_names[9:16] <- paste0(table_names[9:16], "_up to_", date)   # Customizing list names for "From this Date" case
+  
   names(tables) <- table_names
 
   after <- tables[1:8]
 
   current <- tables[9:16]
 
-  if (from == FALSE)
-    x <- current[division]
-
-  if (from != FALSE)
-    x <- after[division]
-
+  if (from == FALSE) {
+    div_date <- paste0(division, "_up to_", date)
+    x <- current[div_date]
+  } else if (from != FALSE) {
+    div_date <- paste0(division, "_after_", date)
+    x <- after[div_date]
+  }
   x
 }


### PR DESCRIPTION
Hello @BillPetti ,

Following this [tweet](https://twitter.com/BillPetti/status/918465231399112705) I've worked around the function `standings_on_date_bref` in order to customize the names of the tables, including the `date` and the option in `from` chosen by the user.

For example, if a user uses now:
`standings_on_date_bref("2017-07-01", "AL East")` he receives the following standings as an output:

> $'AL East'
>    Tm  W  L  W-L%  GB  RS  RA pythW-L%
> 1 BOS 46 35 0.568  -- 384 335    0.562
> 2 NYY 43 36 0.544 2.0 451 340    0.626
> 3 TBR 43 40 0.518 4.0 405 381    0.528
> 4 BAL 39 41 0.488 6.5 356 430    0.414
> 5 TOR 37 43 0.463 8.5 334 365    0.459

With this modification, the user receives the same table but with a better list/table name:

> $'AL East_up to_2017-07-01'
>    Tm  W  L  W-L%  GB  RS  RA pythW-L%
> 1 BOS 46 35 0.568  -- 384 335    0.562
> 2 NYY 43 36 0.544 2.0 451 340    0.626
> 3 TBR 43 40 0.518 4.0 405 381    0.528
> 4 BAL 39 41 0.488 6.5 356 430    0.414
> 5 TOR 37 43 0.463 8.5 334 365    0.459

My idea is to use this function for getting the standings for several days (using a `date` vector between two dates) and then being able to know for which date each standing belongs.

Hope you like it.

Regards.

Daniel Hernández.
