### PR TITLE
Standings’ Games Behind Visualization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,9 @@ Imports:
     rvest,
     XML,
     xml2,
-    magrittr
+    magrittr,
+    pbapply,
+    highcharter
 License: MIT
 URL: https://billpetti.github.io/baseballr/
 BugReports: https://github.com/BillPetti/baseballr/issues

--- a/R/standings_on_date_bref.R
+++ b/R/standings_on_date_bref.R
@@ -17,7 +17,7 @@
 #' standings_on_date_bref("2015-08-04", "AL East")
 #' }
 
-standings_on_date_bref <- function (date, division, from = FALSE) {
+standings_on_date_bref <- function(date, division, from = FALSE) {
 
   stopifnot(intersect(grepl("AL|NL", division), grepl("East|Central|West|Overall",
                                                       division)))
@@ -36,18 +36,21 @@ standings_on_date_bref <- function (date, division, from = FALSE) {
   #table_names <- html_doc %>% rvest::html_nodes(".section_heading") %>% rvest::html_text() %>% gsub(pattern = "\\s+", replacement = " ") %>% gsub(pattern = " Division", replacement = "") %>% trimws(which = c("left")) %>% trimws(which = c("right")) %>% .[1:16]
 
   table_names <- c("NL Overall", "AL Overall", "NL West" , "NL Central", "NL East", "AL West", "AL Central", "AL East", "NL Overall", "AL Overall", "NL West" , "NL Central", "NL East", "AL West", "AL Central", "AL East")
-
+  table_names[1:8] <- paste0(table_names[1:8], "_after_", date)     # Customizing list names for "After this Date" case
+  table_names[9:16] <- paste0(table_names[9:16], "_up to_", date)   # Customizing list names for "From this Date" case
+  
   names(tables) <- table_names
 
   after <- tables[1:8]
 
   current <- tables[9:16]
 
-  if (from == FALSE)
-    x <- current[division]
-
-  if (from != FALSE)
-    x <- after[division]
-
+  if (from == FALSE) {
+    div_date <- paste0(division, "_up to_", date)
+    x <- current[div_date]
+  } else if (from != FALSE) {
+    div_date <- paste0(division, "_after_", date)
+    x <- after[div_date]
+  }
   x
 }

--- a/R/viz_gb_on_period.R
+++ b/R/viz_gb_on_period.R
@@ -1,0 +1,50 @@
+#' Scrape MLB Standings on a Given Period and Visualize the Games Behind (GB) on any division or league the league
+#'
+#' This function allows you to scrape the standings from MLB for a period you choose, and visualize the GB of teams along that period.
+#' @param start_date a date object representing the first date of the period
+#' @param end_date a date object representing the last date of the period
+#' @param div_viz One or more of AL East, AL Central, AL West,
+#' AL Overall, NL East, NL Central, NL West, and NL Overall
+#' @keywords MLB, standings
+#' @importFrom highcharter hchart hc_title hc_subtitle hc_credits hc_yAxis hc_xAxis hc_add_theme
+#' @importFrom pbapply pbsapply
+#' @export viz_gb_on_period
+#' @examples
+#' \dontrun{
+#' viz_gb_on_period("2017-04-02","2017-04-10", "AL East")
+#' }
+
+viz_GB_on_period <- function(start_date, end_date, lg_div) {
+  
+  dates <- seq(as.Date(start_date), as.Date(end_date), by = "days")   # Crate a vector of dates for the period
+  standings <- pbsapply(dates, standings_on_date_bref, division = lg_div)   # 
+  
+  all <- do.call("rbind", standings)
+  all$id <- rep(names(standings), sapply(standings, nrow))
+  rownames(all) <- NULL
+  names(all) <- c("Team", "W", "L", "WLpct", "GB", "RS", "RA", "pythWLpct", "id")
+  all <- all %>% separate(id, c("League", "From", "Date"), "_")
+  all <- tbl_df(all)
+  all$GB[all$GB == "--"] <- 0
+  all$GB <- as.numeric(all$GB, digits = 2)
+  all$pythWLpct[is.na(all$pythWLpct)] <- 0
+  all$Date <- as.Date(all$Date)
+  all <- all %>% select(League, Date, Team, W, L, WLpct, GB)
+  
+  first_end <- all %>%
+    filter(Date == min(Date) | Date == max(Date)) %>% 
+    arrange(Date, GB)
+  print(first_end)
+  
+  hchart(all, "line", hcaes(x = Date, y = GB, group = Team)) %>%
+    hc_title(text = paste(all$League[1], "Standings (GB - Games behind)")) %>%
+    hc_subtitle(text = paste("from", start_date, "to", end_date)) %>% 
+    hc_credits(enabled = TRUE, # add credits
+               text = "Source: Baseball Reference. Using 'baseballr' R package") %>% 
+    hc_yAxis(title = list(text = "GB"),
+             reversed = TRUE) %>%
+    hc_xAxis(title = list(text = "Date")) %>% 
+    hc_add_theme(hc_theme_smpl()) %>% 
+    hc_tooltip(valueDecimals = 1) %>% # round the value to the decimals
+    hc_exporting(enabled = TRUE) # enable exporting option
+}


### PR DESCRIPTION
Hello Bill,

This is a proposal for having a function `viz_gb_on_period` which uses the existing `standings_on_date_bref` function to scrape the standings, but between two dates and then it visualizes the Games Behind (GB) for that period.
I created a file with the function.

> viz_gb_on_period.R
 
Nevertheless, I'm not completely sure if there's something more to do in order to integrate it into the package.

Some notes:

- Of course, if the period is too long, the `standings_on_date_bref` function will need some time to run, so maybe it'll be interesting to evaluate to add a protection;

- Each time we run the function (e.g. for different periods) we'll be scraping info from baseball reference, so maybe it'll be interesting to see if the data being scraped can be saved in the environment for further use in new tries of the function.

Hope it catches your attention.

Best regards.