### PR TITLE
Statcast imputed-data derivation script

### DIFF
--- a/inst/scripts/statcast_impute_derivation.R
+++ b/inst/scripts/statcast_impute_derivation.R
@@ -1,0 +1,41 @@
+
+library(baseballr)
+library(dplyr)
+
+obtain_data = function(start_date="2017-03-29", 
+                       end_date="2017-10-03", type="scrape", infile=NULL) {
+  
+  if (type=="postgres") {
+    # postgres db connection here
+    # e.g.
+    # library(RPostgres)
+    # library(DBI)
+    # conn <- dbConnect(RPostgres::Postgres(), 
+    #  password=SOMEPASS, user=SOME_USER, port=SOME_PORT_PROBABLY_5432, dbname=SOME_NAME)
+    # df1 dbGetQuery(conn, "select * from SOME_TABLE_NAME where game_year=2017")
+    # df1 %>% filter()
+  } else if (type=="rds") {
+    readRDS(infile)
+  } else if (type=="csv") {
+    read.csv(infile, stringsAsFactors = FALSE)
+  } else if (type=="scrape") {
+    date_seq = seq(as.Date(start_date), as.Date(end_date), by=1)
+    dplyr::bind_rows(lapply(date_seq, function(d) {
+      baseballr::scrape_statcast_savant(d, d)
+    }))
+  }
+
+} 
+
+statcast_impute_derive = function(statcast_df, inverse_precision=10000) {
+  # statcast_df must have columns launch_angle, launch_speed, bb_type, events
+  
+  aa = statcast_df %>% filter(!is.na(launch_speed)) %>% mutate(ila=round(launch_angle*inverse_precision), ils=round(launch_speed*inverse_precision))
+  la_ls_count = aa %>% group_by(ila, ils, bb_type, events) %>% summarise(n=n())
+  
+  # use 5 here? some other number? 99.X percentile? this is why it's a heuristic
+  la_ls_filtered = la_ls_count %>% filter(n>=5)
+  
+  la_ls_filtered %>% write.csv("CSV_FILE_TO_LOAD_LATER.csv", row.names = FALSE)
+  
+}

--- a/inst/scripts/statcast_impute_derivation.R
+++ b/inst/scripts/statcast_impute_derivation.R
@@ -1,57 +1,55 @@
-
-
-
 library(baseballr)
 library(dplyr)
 
-obtain_data = function(start_date = "2017-03-29",
-                       end_date = "2017-10-03",
-                       type = "scrape",
-                       infile = NULL) {
+obtain_imputation_training_data = function(start_date = "2017-03-29",
+                                           end_date = "2017-10-03",
+                                           type = "scrape",
+                                           infile = NULL) {
   if (type == "postgres") {
-    # postgres db connection here
+    # postgres db connection here,
     # e.g.
     # library(RPostgres)
     # library(DBI)
     # conn <- dbConnect(RPostgres::Postgres(),
     #  password=SOMEPASS, user=SOME_USER, port=SOME_PORT_PROBABLY_5432, dbname=SOME_NAME)
-    # df1 dbGetQuery(conn, "select * from SOME_TABLE_NAME where game_year=2017")
-    # df1 %>% filter()
+    # df1 <- dbGetQuery(conn, "select * from SOME_TABLE_NAME where game_year=2017")
   } else if (type == "rds") {
     readRDS(infile)
   } else if (type == "csv") {
     read.csv(infile, stringsAsFactors = FALSE)
   } else if (type == "scrape") {
     date_seq = seq(as.Date(start_date), as.Date(end_date), by = 1)
-    
     dplyr::bind_rows(lapply(date_seq, function(d) {
-      scraped_data = baseballr::scrape_statcast_savant(d, d)
+      scraped_data = baseballr::scrape_statcast_savant(d, d) %>% 
+        select("launch_angle", "launch_speed", "bb_type", "events")
       if (nrow(scraped_data) > 0) {
         scraped_data
       } else {
         NULL
       }
-    }))
-    
-    
+    })) %>%   
+      filter(!is.na(launch_speed)) %>%
+      filter(!is.na(launch_angle))
+      
   }
-  
 }
 
-statcast_impute_derive = function(statcast_df, inverse_precision = 10000) {
-  # statcast_df must have columns launch_angle, launch_speed, bb_type, events
+statcast_impute_derive = function(imputation_training_data, inverse_precision = 10000) {
+  # imputation_training_data must be a statcast data frame, 
+  # having columns launch_angle, launch_speed, bb_type, events
   
-  aa = statcast_df %>%
+  la_ls_count = imputation_training_data %>%
     filter(!is.na(launch_speed)) %>%
+    filter(!is.na(launch_angle)) %>%
     mutate(
       ila = round(launch_angle * inverse_precision),
       ils = round(launch_speed * inverse_precision)
-    )
-  la_ls_count = aa %>%
+    ) %>%
     group_by(ila, ils, bb_type, events) %>%
     summarise(n = n())
   
-  # use 5 here? some other number? 99.X percentile? this is why it's a heuristic
+  # use 5 here? some other number? 99.X percentile? this is why I referred to 
+  # it as a heuristic in the `label_statcast_imputed_data` documentation
   la_ls_filtered = la_ls_count %>% filter(n >= 5)
   
   la_ls_filtered %>%

--- a/inst/scripts/statcast_impute_derivation.R
+++ b/inst/scripts/statcast_impute_derivation.R
@@ -1,41 +1,61 @@
 
+
+
 library(baseballr)
 library(dplyr)
 
-obtain_data = function(start_date="2017-03-29", 
-                       end_date="2017-10-03", type="scrape", infile=NULL) {
-  
-  if (type=="postgres") {
+obtain_data = function(start_date = "2017-03-29",
+                       end_date = "2017-10-03",
+                       type = "scrape",
+                       infile = NULL) {
+  if (type == "postgres") {
     # postgres db connection here
     # e.g.
     # library(RPostgres)
     # library(DBI)
-    # conn <- dbConnect(RPostgres::Postgres(), 
+    # conn <- dbConnect(RPostgres::Postgres(),
     #  password=SOMEPASS, user=SOME_USER, port=SOME_PORT_PROBABLY_5432, dbname=SOME_NAME)
     # df1 dbGetQuery(conn, "select * from SOME_TABLE_NAME where game_year=2017")
     # df1 %>% filter()
-  } else if (type=="rds") {
+  } else if (type == "rds") {
     readRDS(infile)
-  } else if (type=="csv") {
+  } else if (type == "csv") {
     read.csv(infile, stringsAsFactors = FALSE)
-  } else if (type=="scrape") {
-    date_seq = seq(as.Date(start_date), as.Date(end_date), by=1)
+  } else if (type == "scrape") {
+    date_seq = seq(as.Date(start_date), as.Date(end_date), by = 1)
+    
     dplyr::bind_rows(lapply(date_seq, function(d) {
-      baseballr::scrape_statcast_savant(d, d)
+      scraped_data = baseballr::scrape_statcast_savant(d, d)
+      if (nrow(scraped_data) > 0) {
+        scraped_data
+      } else {
+        NULL
+      }
     }))
+    
+    
   }
+  
+}
 
-} 
-
-statcast_impute_derive = function(statcast_df, inverse_precision=10000) {
+statcast_impute_derive = function(statcast_df, inverse_precision = 10000) {
   # statcast_df must have columns launch_angle, launch_speed, bb_type, events
   
-  aa = statcast_df %>% filter(!is.na(launch_speed)) %>% mutate(ila=round(launch_angle*inverse_precision), ils=round(launch_speed*inverse_precision))
-  la_ls_count = aa %>% group_by(ila, ils, bb_type, events) %>% summarise(n=n())
+  aa = statcast_df %>%
+    filter(!is.na(launch_speed)) %>%
+    mutate(
+      ila = round(launch_angle * inverse_precision),
+      ils = round(launch_speed * inverse_precision)
+    )
+  la_ls_count = aa %>%
+    group_by(ila, ils, bb_type, events) %>%
+    summarise(n = n())
   
   # use 5 here? some other number? 99.X percentile? this is why it's a heuristic
-  la_ls_filtered = la_ls_count %>% filter(n>=5)
+  la_ls_filtered = la_ls_count %>% filter(n >= 5)
   
-  la_ls_filtered %>% write.csv("CSV_FILE_TO_LOAD_LATER.csv", row.names = FALSE)
+  la_ls_filtered %>%
+    write.csv("CSV_FILE_TO_LOAD_LATER.csv", row.names = FALSE)
   
+  la_ls_filtered
 }


### PR DESCRIPTION
I thought it might be useful to include the script I used to derive the [statcast imputed values](https://github.com/BillPetti/baseballr/pull/71) in the repo. This is good for reproducibility, but additionally this is coming up now because it looks like mlbam changed the data (seems they're no longer providing launch speed & angle on fouls and are rounding angles to integers?), meaning the imputation values probably need to be recomputed. 
