### PR TITLE
Small NCAA schedule bug fix if url missing

### DIFF
--- a/R/ncaa_schedule_info.R
+++ b/R/ncaa_schedule_info.R
@@ -62,9 +62,10 @@ ncaa_schedule_info <- function(teamid = NULL, year = NULL){
   sched <- sched %>%
     dplyr::filter(.data$Date != "")
   sched$opponent_slug <- sched_html %>%
-    rvest::html_elements("td:nth-child(2) > a" ) %>%
+    rvest::html_elements("td:nth-child(2)")%>%
+    rvest::html_element("a") %>%
     rvest::html_attr("href")
-  
+
   sched <- sched %>%
     dplyr::filter(!(.data$Result %in% c("Canceled","Ppd")))
   


### PR DESCRIPTION
If team missing url the url portion of the schedule will fail.

![image](https://user-images.githubusercontent.com/13895464/152611832-ae0b7633-9f35-42b6-84ae-e2921665a46c.png)


 https://stats.ncaa.org/teams/526465

