### PR TITLE
rename header arguments

### DIFF
--- a/R/retrosheet_data.R
+++ b/R/retrosheet_data.R
@@ -159,7 +159,7 @@ create.csv.file <- function(wd, year){
   
   fields <- data.table::fread(paste0(wd, "/fields.csv"))
   
-  payload <- data.table::fread(paste0("all", year, ".csv"), col_names = FALSE)
+  payload <- data.table::fread(paste0("all", year, ".csv"), header = FALSE)
   
   names(payload) <- fields$Header
   
@@ -201,7 +201,7 @@ create.csv.roster <- function(wd, year){
 read.csv2 <- function(wd, file){
   data.table::fread(file = paste0(wd,
                                   "/download.folder/unzipped/", file),
-                    col.names = FALSE)
+                    header = FALSE)
 }
 
 cleanup <- function(wd){


### PR DESCRIPTION
When I downloaded the repo to try to pull retrosheet data, I ran into an interesting issue that `col_names` was an unexpected argument for `data.table::fread`. I tried to get to the bottom of it by reading about `data.table::fread`, but saw there was no `col_names` argument expected at all. Looking at the repository history, my best guess is that it's a holdover from using `readr`, but as for why it was never caught in the refactoring, I don't know.

It appears the intended behavior is achieved through `header`.