### PR TITLE
Update utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -141,7 +141,7 @@ most_recent_ncaa_baseball_season <- function() {
   ifelse(
     as.double(substr(Sys.Date(), 6, 7)) >= 3,
     as.double(substr(Sys.Date(), 1, 4)),
-    as.double(substr(Sys.Date(), 1, 4)-1)
+    as.double(substr(Sys.Date(), 1, 4))-1
   )
 }
 
@@ -153,7 +153,7 @@ most_recent_mlb_season <- function() {
   ifelse(
     as.double(substr(Sys.Date(), 6, 7)) >= 3,
     as.double(substr(Sys.Date(), 1, 4)),
-    as.double(substr(Sys.Date(), 1, 4)-1)
+    as.double(substr(Sys.Date(), 1, 4))-1
   )
 }
 # Functions for custom class


### PR DESCRIPTION
Looks like in the most recent version of R there is an error in the most_recent_mlb_season() function. It throws the following error: Error in substr(Sys.Date(), 1, 4) - 1 : 
  non-numeric argument to binary operator.

Moving the parenthesis fixes it so that you cast the string as a double before subtracting instead.