### PR TITLE
Fixing Pre-2002 data bug in fg_batter_leaders function 

### DIFF
--- a/R/fg_batter_leaders.R
+++ b/R/fg_batter_leaders.R
@@ -453,7 +453,6 @@ fg_batter_leaders <- function(
           "wRC_plus" = "wRC+",
           "WPA_minus" = "-WPA",
           "WPA_plus" = "+WPA", 
-          "FBall_pct" = "FB_pct1",
           "AgeRng" = "AgeR",
           "team_name" = "TeamName",
           "team_name_abb" = "TeamNameAbb") %>%

--- a/R/fg_pitcher_leaders.R
+++ b/R/fg_pitcher_leaders.R
@@ -526,7 +526,6 @@ fg_pitcher_leaders <- function(
           "Relief_IP" = "Relief-IP",
           "WPA_minus" = "-WPA",
           "WPA_plus" = "+WPA", 
-          "FBall_pct" = "FB_pct1",
           "AgeRng" = "AgeR",
           "team_name" = "TeamName",
           "team_name_abb" = "TeamNameAbb") %>%


### PR DESCRIPTION
Removed lines breaking code in both fg_pitcher_leaders and fg_batter_leaders, as pre-2002 seasons don't have the FB_pct1 column, breaking the dplyr chain