### PR TITLE
Fix bug in fg_pitcher_leaders associated with `season` capitalization

### DIFF
--- a/R/fg_pitcher_leaders.R
+++ b/R/fg_pitcher_leaders.R
@@ -534,7 +534,7 @@ fg_pitcher_leaders <- function(
           "Team"
         ))) %>%
         dplyr::select(
-          "Season",
+          "season",
           "team_name",
           "Throws", 
           "xMLBAMID", 


### PR DESCRIPTION
The `fg_pitcher_leaders()` function currently returns an error even when all parameters are correctly specified as a result of `dplyr::select()` attempting to access the `Season` column, when the API query returns `season` (lowercase) instead. This PR fixes the error within the `fg_pitcher_leaders()` function. It may be worth further investigation into potential effects of this renaming on other `fg_` functions.