### PR TITLE
Add Bat Tracking Columns To Statcast Search

### DIFF
--- a/R/sc_statcast_search.R
+++ b/R/sc_statcast_search.R
@@ -106,6 +106,8 @@
 #'   |spin_axis                       |numeric   |
 #'   |delta_home_win_exp              |numeric   |
 #'   |delta_run_exp                   |numeric   |
+#'   |bat_speed                       |numeric   |
+#'   |swing_length                    |numeric   |
 #' 
 #' @importFrom tibble tribble
 #' @importFrom lubridate year
@@ -242,7 +244,7 @@ statcast_search <- function(start_date = Sys.Date() - 1, end_date = Sys.Date(),
                         "pitch_number", "pitch_name", "home_score", "away_score", "bat_score",
                         "fld_score", "post_away_score", "post_home_score", "post_bat_score",
                         "post_fld_score", "if_fielding_alignment", "of_fielding_alignment",
-                        "spin_axis", "delta_home_win_exp", "delta_run_exp")
+                        "spin_axis", "delta_home_win_exp", "delta_run_exp", "bat_speed", "swing_length")
     payload <- process_statcast_payload(payload) %>%
       make_baseballr_data("MLB Baseball Savant Statcast Search data from baseballsavant.mlb.com",Sys.time())
     return(payload)
@@ -268,7 +270,7 @@ statcast_search <- function(start_date = Sys.Date() - 1, end_date = Sys.Date(),
                         "pitch_number", "pitch_name", "home_score", "away_score", "bat_score",
                         "fld_score", "post_away_score", "post_home_score", "post_bat_score",
                         "post_fld_score", "if_fielding_alignment", "of_fielding_alignment",
-                        "spin_axis", "delta_home_win_exp", "delta_run_exp")
+                        "spin_axis", "delta_home_win_exp", "delta_run_exp", "bat_speed", "swing_length")
     payload <- payload %>%
       make_baseballr_data("MLB Baseball Savant Statcast Search data from baseballsavant.mlb.com",Sys.time())
     return(payload)
@@ -407,6 +409,8 @@ statcast_search.default <- function(start_date = Sys.Date() - 1, end_date = Sys.
 #'   |spin_axis                       |numeric   |
 #'   |delta_home_win_exp              |numeric   |
 #'   |delta_run_exp                   |numeric   |
+#'   |bat_speed                       |numeric   |
+#'   |swing_length                    |numeric   |   
 #'   
 #' @export
 #' @examples
@@ -523,6 +527,8 @@ statcast_search_batters <- function(start_date, end_date, batterid = NULL, ...) 
 #'   |spin_axis                       |numeric   |
 #'   |delta_home_win_exp              |numeric   |
 #'   |delta_run_exp                   |numeric   |
+#'   |bat_speed                       |numeric   |
+#'   |swing_length                    |numeric   |
 #' 
 #' @export
 #' @examples

--- a/man/statcast_search.Rd
+++ b/man/statcast_search.Rd
@@ -140,6 +140,8 @@ Returns a tibble with Statcast data with the following columns:\tabular{ll}{
    spin_axis \tab numeric \cr
    delta_home_win_exp \tab numeric \cr
    delta_run_exp \tab numeric \cr
+   bat_speed \tab numeric \cr
+   swing_length \tab numeric \cr
 }
 
 Returns a tibble with Statcast data.
@@ -238,6 +240,8 @@ Returns a tibble with Statcast data with the following columns:\tabular{ll}{
    spin_axis \tab numeric \cr
    delta_home_win_exp \tab numeric \cr
    delta_run_exp \tab numeric \cr
+   bat_speed \tab numeric \cr
+   swing_length \tab numeric \cr
 }
 
 Returns a tibble with Statcast data with the following columns:\tabular{ll}{
@@ -334,6 +338,8 @@ Returns a tibble with Statcast data with the following columns:\tabular{ll}{
    spin_axis \tab numeric \cr
    delta_home_win_exp \tab numeric \cr
    delta_run_exp \tab numeric \cr
+   bat_speed \tab numeric \cr
+   swing_length \tab numeric \cr
 }
 }
 \description{

--- a/tests/testthat/test-statcast_search.R
+++ b/tests/testthat/test-statcast_search.R
@@ -22,7 +22,7 @@ cols <- c(
   "away_score", "bat_score", "fld_score", "post_away_score", 
   "post_home_score", "post_bat_score", "post_fld_score",
   "if_fielding_alignment", "of_fielding_alignment",
-  "spin_axis", "delta_home_win_exp", "delta_run_exp"
+  "spin_axis", "delta_home_win_exp", "delta_run_exp", "bat_speed", "swing_length"
 )
 
 test_that("Statcast Search", {


### PR DESCRIPTION
Baseball Savant rolled out new bat tracking data in the past 24 hours, so the search now needs to include those columns in the returned data

Closes #331 
