### PR TITLE
Update Depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ URL: https://billpetti.github.io/baseballr/,
     https://github.com/BillPetti/baseballr
 BugReports: https://github.com/BillPetti/baseballr/issues
 Depends:
-    R (>= 4.0.0)
+    R (>= 4.1.0)
 Imports: 
     cli (>= 3.4.1),
     data.table (>= 1.14.0),


### PR DESCRIPTION
Updated `Depends` field to `Depends: R (>= 4.1.0)` in DESCRIPTION, so as to get rid of the CRAN note:
```
Version: 1.6.0
Check: DESCRIPTION meta-information
Result: NOTE
    Missing dependency on R >= 4.1.0 because package code uses the pipe
    |> or function shorthand \(...) syntax added in R 4.1.0.
    File(s) using such syntax:
      ‘chadwick_installation.R’
```
See here:
[https://cran.r-project.org/web/checks/check_results_baseballr.html](https://cran.r-project.org/web/checks/check_results_baseballr.html)