### PR TITLE
 Making changes for mlb_pbp function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: baseballr
 Title: Acquiring and Analyzing Baseball Data
-Version: 1.6.0.9001
+Version: 1.6.0.9002
 Authors@R: c(
     person("Bill", "Petti", , "billpetti@gmail.com", role = "aut"),
     person("Saiem", "Gilani", , "saiem.gilani@gmail.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # baseballr (development version)
 
 - Hotfix for `statcast_search` with the new column definitions v(1.6.0.9001)
+- Hotfix for `statcast_search` with the new column definitions v(1.6.0.9002)
 
 # baseballr 1.6.0
 

--- a/R/mlb_pbp.R
+++ b/R/mlb_pbp.R
@@ -210,8 +210,26 @@ mlb_pbp <- function(game_pk) {
       at_bats <- at_bats %>%
         dplyr::select(-c(tidyr::one_of(list_columns)))
       
-      pbp <- plays %>%
-        dplyr::left_join(at_bats, by = c("endTime" = "playEndTime"))
+      if (all(!is.na(plays$startTime)) & all(!is.na(plays$endTime))) {
+        pbp <- plays %>%
+          dplyr::left_join(at_bats, by = c("endTime" = "playEndTime"))
+      }
+      else {
+        plays <- plays %>%
+          dplyr::mutate(atBatIndex_from_id = as.integer(substring(playId, 11, 12)),
+                        pitchNumber_from_id = as.numeric(substring(playId, 16, 17))) %>%
+          dplyr::filter(!is.na(atBatIndex_from_id)) %>%
+          group_by(atBatIndex_from_id) %>%
+          mutate(is_final_pitch = pitchNumber_from_id == max(pitchNumber_from_id, na.rm = TRUE)) %>%
+          ungroup() %>%
+          dplyr::select(-any_of(c("count.balls", "count.strikes", "count.outs")))
+
+        pbp <- plays %>%
+          dplyr::left_join(at_bats, by = c("atBatIndex_from_id" = "atBatIndex"))
+        
+        pbp <- pbp %>%
+          dplyr::rename(atBatIndex = atBatIndex_from_id)
+      }
       
       pbp <- pbp %>%
         tidyr::fill("atBatIndex":"matchup.splits.menOnBase", .direction = "up") %>%

--- a/R/mlb_pbp.R
+++ b/R/mlb_pbp.R
@@ -216,7 +216,7 @@ mlb_pbp <- function(game_pk) {
       }
       else {
         plays <- plays %>%
-          dplyr::mutate(atBatIndex_from_id = as.integer(substring(playId, 11, 12)),
+          dplyr::mutate(atBatIndex_from_id = as.integer(substring(playId, 11, 12)) - 1,
                         pitchNumber_from_id = as.numeric(substring(playId, 16, 17))) %>%
           dplyr::filter(!is.na(atBatIndex_from_id)) %>%
           group_by(atBatIndex_from_id) %>%

--- a/R/sc_statcast_search.R
+++ b/R/sc_statcast_search.R
@@ -12,121 +12,126 @@
 #' @param ... currently ignored
 #' @return Returns a tibble with Statcast data with the following columns:
 #' 
-#'   |col_name                         |types     |
-#'   |:--------------------------------|:---------|
-#'   |pitch_type                       |character |
-#'   |game_date                        |Date      |
-#'   |release_speed                    |numeric   |
-#'   |release_pos_x                    |numeric   |
-#'   |release_pos_z                    |numeric   |
-#'   |player_name                      |character |
-#'   |batter                           |numeric   |
-#'   |pitcher                          |numeric   |
-#'   |events                           |character |
-#'   |description                      |character |
-#'   |spin_dir                         |logical   |
-#'   |spin_rate_deprecated             |logical   |
-#'   |break_angle_deprecated           |logical   |
-#'   |break_length_deprecated          |logical   |
-#'   |zone                             |numeric   |
-#'   |des                              |character |
-#'   |game_type                        |character |
-#'   |stand                            |character |
-#'   |p_throws                         |character |
-#'   |home_team                        |character |
-#'   |away_team                        |character |
-#'   |type                             |character |
-#'   |hit_location                     |integer   |
-#'   |bb_type                          |character |
-#'   |balls                            |integer   |
-#'   |strikes                          |integer   |
-#'   |game_year                        |integer   |
-#'   |pfx_x                            |numeric   |
-#'   |pfx_z                            |numeric   |
-#'   |plate_x                          |numeric   |
-#'   |plate_z                          |numeric   |
-#'   |on_3b                            |numeric   |
-#'   |on_2b                            |numeric   |
-#'   |on_1b                            |numeric   |
-#'   |outs_when_up                     |integer   |
-#'   |inning                           |numeric   |
-#'   |inning_topbot                    |character |
-#'   |hc_x                             |numeric   |
-#'   |hc_y                             |numeric   |
-#'   |tfs_deprecated                   |logical   |
-#'   |tfs_zulu_deprecated              |logical   |
-#'   |fielder_2                        |numeric   |
-#'   |umpire                           |logical   |
-#'   |sv_id                            |character |
-#'   |vx0                              |numeric   |
-#'   |vy0                              |numeric   |
-#'   |vz0                              |numeric   |
-#'   |ax                               |numeric   |
-#'   |ay                               |numeric   |
-#'   |az                               |numeric   |
-#'   |sz_top                           |numeric   |
-#'   |sz_bot                           |numeric   |
-#'   |hit_distance_sc                  |numeric   |
-#'   |launch_speed                     |numeric   |
-#'   |launch_angle                     |numeric   |
-#'   |effective_speed                  |numeric   |
-#'   |release_spin_rate                |numeric   |
-#'   |release_extension                |numeric   |
-#'   |game_pk                          |numeric   |
-#'   |fielder_3                        |numeric   |
-#'   |fielder_4                        |numeric   |
-#'   |fielder_5                        |numeric   |
-#'   |fielder_6                        |numeric   |
-#'   |fielder_7                        |numeric   |
-#'   |fielder_8                        |numeric   |
-#'   |fielder_9                        |numeric   |
-#'   |release_pos_y                    |numeric   |
-#'   |estimated_ba_using_speedangle    |numeric   |
-#'   |estimated_woba_using_speedangle  |numeric   |
-#'   |woba_value                       |numeric   |
-#'   |woba_denom                       |integer   |
-#'   |babip_value                      |integer   |
-#'   |iso_value                        |integer   |
-#'   |launch_speed_angle               |integer   |
-#'   |at_bat_number                    |numeric   |
-#'   |pitch_number                     |numeric   |
-#'   |pitch_name                       |character |
-#'   |home_score                       |numeric   |
-#'   |away_score                       |numeric   |
-#'   |bat_score                        |numeric   |
-#'   |fld_score                        |numeric   |
-#'   |post_away_score                  |numeric   |
-#'   |post_home_score                  |numeric   |
-#'   |post_bat_score                   |numeric   |
-#'   |post_fld_score                   |numeric   |
-#'   |if_fielding_alignment            |character |
-#'   |of_fielding_alignment            |character |
-#'   |spin_axis                        |numeric   |
-#'   |delta_home_win_exp               |numeric   |
-#'   |delta_run_exp                    |numeric   |
-#'   |bat_speed                        |character |
-#'   |swing_length                     |character |
-#'   |estimated_slg_using_speedangle   |numeric   |
-#'   |delta_pitcher_run_exp            |numeric   |
-#'   |hyper_speed                      |numeric   |
-#'   |home_score_diff                  |numeric   |
-#'   |bat_score_diff                   |numeric   |
-#'   |home_win_exp                     |numeric   |
-#'   |bat_win_exp                      |numeric   |
-#'   |age_pit_legacy                   |numeric   |
-#'   |age_bat_legacy                   |numeric   |
-#'   |age_pit                          |numeric   |
-#'   |age_bat                          |numeric   |
-#'   |n_thruorder_pitcher              |numeric   |
-#'   |n_priorpa_thisgame_player_at_bat |numeric   |
-#'   |pitcher_days_since_prev_game     |numeric   |
-#'   |batter_days_since_prev_game      |numeric   |
-#'   |pitcher_days_until_next_game     |numeric   |
-#'   |batter_days_until_next_game      |numeric   |
-#'   |api_break_z_with_gravity         |numeric   |
-#'   |api_break_x_arm                  |numeric   |
-#'   |api_break_x_batter_in            |numeric   |
-#'   |arm_angle                        |numeric   |
+#'   |col_name                                     |types     |
+#'   |:--------------------------------------------|:---------|
+#'   |pitch_type                                   |character |
+#'   |game_date                                    |Date      |
+#'   |release_speed                                |numeric   |
+#'   |release_pos_x                                |numeric   |
+#'   |release_pos_z                                |numeric   |
+#'   |player_name                                  |character |
+#'   |batter                                       |numeric   |
+#'   |pitcher                                      |numeric   |
+#'   |events                                       |character |
+#'   |description                                  |character |
+#'   |spin_dir                                     |logical   |
+#'   |spin_rate_deprecated                         |logical   |
+#'   |break_angle_deprecated                       |logical   |
+#'   |break_length_deprecated                      |logical   |
+#'   |zone                                         |numeric   |
+#'   |des                                          |character |
+#'   |game_type                                    |character |
+#'   |stand                                        |character |
+#'   |p_throws                                     |character |
+#'   |home_team                                    |character |
+#'   |away_team                                    |character |
+#'   |type                                         |character |
+#'   |hit_location                                 |integer   |
+#'   |bb_type                                      |character |
+#'   |balls                                        |integer   |
+#'   |strikes                                      |integer   |
+#'   |game_year                                    |integer   |
+#'   |pfx_x                                        |numeric   |
+#'   |pfx_z                                        |numeric   |
+#'   |plate_x                                      |numeric   |
+#'   |plate_z                                      |numeric   |
+#'   |on_3b                                        |numeric   |
+#'   |on_2b                                        |numeric   |
+#'   |on_1b                                        |numeric   |
+#'   |outs_when_up                                 |integer   |
+#'   |inning                                       |numeric   |
+#'   |inning_topbot                                |character |
+#'   |hc_x                                         |numeric   |
+#'   |hc_y                                         |numeric   |
+#'   |tfs_deprecated                               |logical   |
+#'   |tfs_zulu_deprecated                          |logical   |
+#'   |umpire                                       |logical   |
+#'   |sv_id                                        |character |
+#'   |vx0                                          |numeric   |
+#'   |vy0                                          |numeric   |
+#'   |vz0                                          |numeric   |
+#'   |ax                                           |numeric   |
+#'   |ay                                           |numeric   |
+#'   |az                                           |numeric   |
+#'   |sz_top                                       |numeric   |
+#'   |sz_bot                                       |numeric   |
+#'   |hit_distance_sc                              |numeric   |
+#'   |launch_speed                                 |numeric   |
+#'   |launch_angle                                 |numeric   |
+#'   |effective_speed                              |numeric   |
+#'   |release_spin_rate                            |numeric   |
+#'   |release_extension                            |numeric   |
+#'   |game_pk                                      |numeric   |
+#'   |fielder_2                                    |numeric   |
+#'   |fielder_3                                    |numeric   |
+#'   |fielder_4                                    |numeric   |
+#'   |fielder_5                                    |numeric   |
+#'   |fielder_6                                    |numeric   |
+#'   |fielder_7                                    |numeric   |
+#'   |fielder_8                                    |numeric   |
+#'   |fielder_9                                    |numeric   |
+#'   |release_pos_y                                |numeric   |
+#'   |estimated_ba_using_speedangle                |numeric   |
+#'   |estimated_woba_using_speedangle              |numeric   |
+#'   |woba_value                                   |numeric   |
+#'   |woba_denom                                   |integer   |
+#'   |babip_value                                  |integer   |
+#'   |iso_value                                    |integer   |
+#'   |launch_speed_angle                           |integer   |
+#'   |at_bat_number                                |numeric   |
+#'   |pitch_number                                 |numeric   |
+#'   |pitch_name                                   |character |
+#'   |home_score                                   |numeric   |
+#'   |away_score                                   |numeric   |
+#'   |bat_score                                    |numeric   |
+#'   |fld_score                                    |numeric   |
+#'   |post_away_score                              |numeric   |
+#'   |post_home_score                              |numeric   |
+#'   |post_bat_score                               |numeric   |
+#'   |post_fld_score                               |numeric   |
+#'   |if_fielding_alignment                        |character |
+#'   |of_fielding_alignment                        |character |
+#'   |spin_axis                                    |numeric   |
+#'   |delta_home_win_exp                           |numeric   |
+#'   |delta_run_exp                                |numeric   |
+#'   |bat_speed                                    |numeric   |
+#'   |swing_length                                 |numeric   |
+#'   |estimated_slg_using_speedangle               |numeric   |
+#'   |delta_pitcher_run_exp                        |numeric   |
+#'   |hyper_speed                                  |numeric   |
+#'   |home_score_diff                              |numeric   |
+#'   |bat_score_diff                               |numeric   |
+#'   |home_win_exp                                 |numeric   |
+#'   |bat_win_exp                                  |numeric   |
+#'   |age_pit_legacy                               |numeric   |
+#'   |age_bat_legacy                               |numeric   |
+#'   |age_pit                                      |numeric   |
+#'   |age_bat                                      |numeric   |
+#'   |n_thruorder_pitcher                          |numeric   |
+#'   |n_priorpa_thisgame_player_at_bat             |numeric   |
+#'   |pitcher_days_since_prev_game                 |numeric   |
+#'   |batter_days_since_prev_game                  |numeric   |
+#'   |pitcher_days_until_next_game                 |numeric   |
+#'   |batter_days_until_next_game                  |numeric   |
+#'   |api_break_z_with_gravity	                   |numeric   |
+#'   |api_break_x_arm                              |numeric   |
+#'   |api_break_x_batter_in                        |numeric   |
+#'   |arm_angle	                                   |numeric   |
+#'   |attack_angle                                 |numeric   |
+#'   |attack_direction	                           |numeric   |
+#'   |swing_path_tilt                              |numeric   |
+#'   |intercept_ball_minus_batter_pos_x_inches     |numeric   |	
+#'   |intercept_ball_minus_batter_pos_y_inches     |numeric   |
 #' 
 #' @importFrom tibble tribble
 #' @importFrom lubridate year
@@ -244,34 +249,37 @@ statcast_search <- function(start_date = Sys.Date() - 1, end_date = Sys.Date(),
   # returns 0 rows on failure but > 1 columns
   if (nrow(payload) > 1) {
 
-    names(payload) <- c("pitch_type", "game_date", "release_speed", "release_pos_x", 
-                        "release_pos_z", "player_name", "batter", "pitcher", "events", 
-                        "description", "spin_dir", "spin_rate_deprecated", "break_angle_deprecated", 
-                        "break_length_deprecated", "zone", "des", "game_type", "stand", 
-                        "p_throws", "home_team", "away_team", "type", "hit_location", 
-                        "bb_type", "balls", "strikes", "game_year", "pfx_x", "pfx_z", 
-                        "plate_x", "plate_z", "on_3b", "on_2b", "on_1b", "outs_when_up", 
-                        "inning", "inning_topbot", "hc_x", "hc_y", "tfs_deprecated", 
-                        "tfs_zulu_deprecated", "umpire", "sv_id", 
-                        "vx0", "vy0", "vz0", "ax", "ay", "az", "sz_top", "sz_bot", "hit_distance_sc", 
-                        "launch_speed", "launch_angle", "effective_speed", "release_spin_rate", 
-                        "release_extension", "game_pk", "fielder_2", 
-                        "fielder_3", "fielder_4", "fielder_5", "fielder_6", "fielder_7", 
-                        "fielder_8", "fielder_9", "release_pos_y", "estimated_ba_using_speedangle", 
-                        "estimated_woba_using_speedangle", "woba_value", "woba_denom", 
-                        "babip_value", "iso_value", "launch_speed_angle", "at_bat_number", 
-                        "pitch_number", "pitch_name", "home_score", "away_score", "bat_score", 
-                        "fld_score", "post_away_score", "post_home_score", "post_bat_score", 
-                        "post_fld_score", "if_fielding_alignment", "of_fielding_alignment", 
-                        "spin_axis", "delta_home_win_exp", "delta_run_exp","bat_speed", "swing_length", 
-                        "estimated_slg_using_speedangle", 
-                        "delta_pitcher_run_exp", "hyper_speed", "home_score_diff", "bat_score_diff", 
-                        "home_win_exp", "bat_win_exp", "age_pit_legacy", "age_bat_legacy", 
-                        "age_pit", "age_bat", "n_thruorder_pitcher", "n_priorpa_thisgame_player_at_bat", 
-                        "pitcher_days_since_prev_game", "batter_days_since_prev_game", 
-                        "pitcher_days_until_next_game", "batter_days_until_next_game", 
-                        "api_break_z_with_gravity", "api_break_x_arm", "api_break_x_batter_in", 
-                        "arm_angle")
+    names(payload) <- c("pitch_type", "game_date", "release_speed", "release_pos_x",
+                        "release_pos_z", "player_name", "batter", "pitcher", "events",
+                        "description", "spin_dir", "spin_rate_deprecated", "break_angle_deprecated",
+                        "break_length_deprecated", "zone", "des", "game_type", "stand",
+                        "p_throws", "home_team", "away_team", "type", "hit_location",
+                        "bb_type", "balls", "strikes", "game_year", "pfx_x", "pfx_z",
+                        "plate_x", "plate_z", "on_3b", "on_2b", "on_1b", "outs_when_up",
+                        "inning", "inning_topbot", "hc_x", "hc_y", "tfs_deprecated",
+                        "tfs_zulu_deprecated", "umpire", "sv_id", "vx0",
+                        "vy0", "vz0", "ax", "ay", "az", "sz_top", "sz_bot", "hit_distance_sc",
+                        "launch_speed", "launch_angle", "effective_speed", "release_spin_rate",
+                        "release_extension", "game_pk", "fielder_2",
+                        "fielder_3", "fielder_4", "fielder_5", "fielder_6", "fielder_7",
+                        "fielder_8", "fielder_9", "release_pos_y", "estimated_ba_using_speedangle",
+                        "estimated_woba_using_speedangle", "woba_value", "woba_denom",
+                        "babip_value", "iso_value", "launch_speed_angle", "at_bat_number",
+                        "pitch_number", "pitch_name", "home_score", "away_score", "bat_score",
+                        "fld_score", "post_away_score", "post_home_score", "post_bat_score",
+                        "post_fld_score", "if_fielding_alignment", "of_fielding_alignment",
+                        "spin_axis", "delta_home_win_exp", "delta_run_exp",
+                        "bat_speed",	"swing_length",	"estimated_slg_using_speedangle",	
+                        "delta_pitcher_run_exp",	"hyper_speed",	"home_score_diff",
+                        "bat_score_diff",	"home_win_exp",	"bat_win_exp",	"age_pit_legacy",
+                        "age_bat_legacy",	"age_pit",	"age_bat",	"n_thruorder_pitcher",
+                        "n_priorpa_thisgame_player_at_bat",	"pitcher_days_since_prev_game",
+                        "batter_days_since_prev_game",	"pitcher_days_until_next_game",
+                        "batter_days_until_next_game",	"api_break_z_with_gravity",
+                        "api_break_x_arm",	"api_break_x_batter_in",
+                        "arm_angle",	"attack_angle",	"attack_direction",
+                        "swing_path_tilt",	"intercept_ball_minus_batter_pos_x_inches",
+                        "intercept_ball_minus_batter_pos_y_inches")
     
     payload <- process_statcast_payload(payload) %>%
       make_baseballr_data("MLB Baseball Savant Statcast Search data from baseballsavant.mlb.com",Sys.time())
@@ -279,34 +287,37 @@ statcast_search <- function(start_date = Sys.Date() - 1, end_date = Sys.Date(),
   } else {
     warning("No valid data found")
 
-    names(payload) <- c("pitch_type", "game_date", "release_speed", "release_pos_x", 
-                        "release_pos_z", "player_name", "batter", "pitcher", "events", 
-                        "description", "spin_dir", "spin_rate_deprecated", "break_angle_deprecated", 
-                        "break_length_deprecated", "zone", "des", "game_type", "stand", 
-                        "p_throws", "home_team", "away_team", "type", "hit_location", 
-                        "bb_type", "balls", "strikes", "game_year", "pfx_x", "pfx_z", 
-                        "plate_x", "plate_z", "on_3b", "on_2b", "on_1b", "outs_when_up", 
-                        "inning", "inning_topbot", "hc_x", "hc_y", "tfs_deprecated", 
-                        "tfs_zulu_deprecated", "umpire", "sv_id", 
-                        "vx0", "vy0", "vz0", "ax", "ay", "az", "sz_top", "sz_bot", "hit_distance_sc", 
-                        "launch_speed", "launch_angle", "effective_speed", "release_spin_rate", 
-                        "release_extension", "game_pk", "fielder_2", 
-                        "fielder_3", "fielder_4", "fielder_5", "fielder_6", "fielder_7", 
-                        "fielder_8", "fielder_9", "release_pos_y", "estimated_ba_using_speedangle", 
-                        "estimated_woba_using_speedangle", "woba_value", "woba_denom", 
-                        "babip_value", "iso_value", "launch_speed_angle", "at_bat_number", 
-                        "pitch_number", "pitch_name", "home_score", "away_score", "bat_score", 
-                        "fld_score", "post_away_score", "post_home_score", "post_bat_score", 
-                        "post_fld_score", "if_fielding_alignment", "of_fielding_alignment", 
-                        "spin_axis", "delta_home_win_exp", "delta_run_exp","bat_speed", "swing_length", 
-                        "estimated_slg_using_speedangle", 
-                        "delta_pitcher_run_exp", "hyper_speed", "home_score_diff", "bat_score_diff", 
-                        "home_win_exp", "bat_win_exp", "age_pit_legacy", "age_bat_legacy", 
-                        "age_pit", "age_bat", "n_thruorder_pitcher", "n_priorpa_thisgame_player_at_bat", 
-                        "pitcher_days_since_prev_game", "batter_days_since_prev_game", 
-                        "pitcher_days_until_next_game", "batter_days_until_next_game", 
-                        "api_break_z_with_gravity", "api_break_x_arm", "api_break_x_batter_in", 
-                        "arm_angle")
+    names(payload) <- c("pitch_type", "game_date", "release_speed", "release_pos_x",
+                        "release_pos_z", "player_name", "batter", "pitcher", "events",
+                        "description", "spin_dir", "spin_rate_deprecated", "break_angle_deprecated",
+                        "break_length_deprecated", "zone", "des", "game_type", "stand",
+                        "p_throws", "home_team", "away_team", "type", "hit_location",
+                        "bb_type", "balls", "strikes", "game_year", "pfx_x", "pfx_z",
+                        "plate_x", "plate_z", "on_3b", "on_2b", "on_1b", "outs_when_up",
+                        "inning", "inning_topbot", "hc_x", "hc_y", "tfs_deprecated",
+                        "tfs_zulu_deprecated", "umpire", "sv_id", "vx0",
+                        "vy0", "vz0", "ax", "ay", "az", "sz_top", "sz_bot", "hit_distance_sc",
+                        "launch_speed", "launch_angle", "effective_speed", "release_spin_rate",
+                        "release_extension", "game_pk", "fielder_2",
+                        "fielder_3", "fielder_4", "fielder_5", "fielder_6", "fielder_7",
+                        "fielder_8", "fielder_9", "release_pos_y", "estimated_ba_using_speedangle",
+                        "estimated_woba_using_speedangle", "woba_value", "woba_denom",
+                        "babip_value", "iso_value", "launch_speed_angle", "at_bat_number",
+                        "pitch_number", "pitch_name", "home_score", "away_score", "bat_score",
+                        "fld_score", "post_away_score", "post_home_score", "post_bat_score",
+                        "post_fld_score", "if_fielding_alignment", "of_fielding_alignment",
+                        "spin_axis", "delta_home_win_exp", "delta_run_exp",
+                        "bat_speed",	"swing_length",	"estimated_slg_using_speedangle",	
+                        "delta_pitcher_run_exp",	"hyper_speed",	"home_score_diff",
+                        "bat_score_diff",	"home_win_exp",	"bat_win_exp",	"age_pit_legacy",
+                        "age_bat_legacy",	"age_pit",	"age_bat",	"n_thruorder_pitcher",
+                        "n_priorpa_thisgame_player_at_bat",	"pitcher_days_since_prev_game",
+                        "batter_days_since_prev_game",	"pitcher_days_until_next_game",
+                        "batter_days_until_next_game",	"api_break_z_with_gravity",
+                        "api_break_x_arm",	"api_break_x_batter_in",
+                        "arm_angle",	"attack_angle",	"attack_direction",
+                        "swing_path_tilt",	"intercept_ball_minus_batter_pos_x_inches",
+                        "intercept_ball_minus_batter_pos_y_inches")
     
     payload <- payload %>%
       make_baseballr_data("MLB Baseball Savant Statcast Search data from baseballsavant.mlb.com",Sys.time())

--- a/man/statcast_search.Rd
+++ b/man/statcast_search.Rd
@@ -89,7 +89,6 @@ Returns a tibble with Statcast data with the following columns:\tabular{ll}{
    hc_y \tab numeric \cr
    tfs_deprecated \tab logical \cr
    tfs_zulu_deprecated \tab logical \cr
-   fielder_2 \tab numeric \cr
    umpire \tab logical \cr
    sv_id \tab character \cr
    vx0 \tab numeric \cr
@@ -107,6 +106,7 @@ Returns a tibble with Statcast data with the following columns:\tabular{ll}{
    release_spin_rate \tab numeric \cr
    release_extension \tab numeric \cr
    game_pk \tab numeric \cr
+   fielder_2 \tab numeric \cr
    fielder_3 \tab numeric \cr
    fielder_4 \tab numeric \cr
    fielder_5 \tab numeric \cr
@@ -138,8 +138,8 @@ Returns a tibble with Statcast data with the following columns:\tabular{ll}{
    spin_axis \tab numeric \cr
    delta_home_win_exp \tab numeric \cr
    delta_run_exp \tab numeric \cr
-   bat_speed \tab character \cr
-   swing_length \tab character \cr
+   bat_speed \tab numeric \cr
+   swing_length \tab numeric \cr
    estimated_slg_using_speedangle \tab numeric \cr
    delta_pitcher_run_exp \tab numeric \cr
    hyper_speed \tab numeric \cr
@@ -161,6 +161,11 @@ Returns a tibble with Statcast data with the following columns:\tabular{ll}{
    api_break_x_arm \tab numeric \cr
    api_break_x_batter_in \tab numeric \cr
    arm_angle \tab numeric \cr
+   attack_angle \tab numeric \cr
+   attack_direction \tab numeric \cr
+   swing_path_tilt \tab numeric \cr
+   intercept_ball_minus_batter_pos_x_inches \tab numeric \cr
+   intercept_ball_minus_batter_pos_y_inches \tab numeric \cr
 }
 
 Returns a tibble with Statcast data.


### PR DESCRIPTION
## Description
Fixes play-by-play data retrieval for Rookie level games.

## Problem
The `mlb_pbp()` function was failing for most of the Rookie level games because the API returns a different data structure. Specifically:
- Rookie level games don't have `endTime` on every pitch

## Solution
- Add conditional logic to detect Rookie level games
- Use the fact that the `playId` field has a different structure that encodes the atBatIndex
- Extract `atBatIndex` from the `playId` structure (characters 11-12)
- Remove overlapping columns before join to prevent conflicts
- Filter out NA values to prevent warnings