### PR TITLE
Clean up of errors when query parameters change in the fg_pitcher_leaders function

### DIFF
--- a/R/fg_pitcher_leaders.R
+++ b/R/fg_pitcher_leaders.R
@@ -480,8 +480,8 @@ fg_pitcher_leaders <- function(
     stats = stats,
     lg = lg,
     qual = qual,
-    season = startseason,
-    season1 = endseason,
+    season = endseason,
+    season1 = startseason,
     startdate = startdate,
     enddate = enddate,
     month = month,
@@ -521,20 +521,20 @@ fg_pitcher_leaders <- function(
       leaders <- fg_df %>% 
         dplyr::rename_with(~ gsub("pi", "pi_", .x), starts_with("pi")) %>% 
         dplyr::rename_with(~ gsub("pfx", "pfx_", .x), starts_with("pfx")) %>%
-        dplyr::rename(
+         dplyr::rename(any_of(c(
           "Start_IP" = "Start-IP",
           "Relief_IP" = "Relief-IP",
           "WPA_minus" = "-WPA",
           "WPA_plus" = "+WPA", 
           "AgeRng" = "AgeR",
           "team_name" = "TeamName",
-          "team_name_abb" = "TeamNameAbb") %>%
+          "team_name_abb" = "TeamNameAbb"))) %>%
         dplyr::select(-dplyr::any_of(c(
           "Name", 
           "Team"
         ))) %>%
         dplyr::select(
-          "season",
+          "Season",
           "team_name",
           "Throws", 
           "xMLBAMID", 


### PR DESCRIPTION
- Swapped season parameters to match the Fangraphs API string. Was reversed previously, which caused errors for multiseason queries.
- Added proper capitalization of Season variable.
- Added logic in column renaming as to not error when a column isn't present. This occurred when querying as starting pitchers only OR when querying as reliever only (stats = "str" or stats = "rel")