### PR TITLE
fix(bref): repair Baseball Reference scrapers + list MLB Stats before ESPN MLB in pkgdown

### DIFF
--- a/R/bref_daily_batter.R
+++ b/R/bref_daily_batter.R
@@ -8,6 +8,7 @@
 #'
 #'  |col_name |types     |description                                              |
 #'  |:--------|:---------|:--------------------------------------------------------|
+#'  |bbref_id |character |Baseball-Reference player id (slug).                     |
 #'  |season   |integer   |Season year.                                             |
 #'  |Name     |character |Player name.                                             |
 #'  |Age      |numeric   |Player age during the season.                            |
@@ -52,7 +53,7 @@ bref_daily_batter <- function(t1, t2) {
   df <- NULL
   tryCatch(
     expr = {
-      payload <- xml2::read_html(paste0("http://www.baseball-reference.com/leagues/daily.cgi?user_team=&bust_cache=&type=b&lastndays=7&dates=fromandto&fromandto=", t1, ".", t2, "&level=mlb&franch=&stat=&stat_value=0"))
+      payload <- xml2::read_html(paste0("https://www.baseball-reference.com/leagues/daily.cgi?user_team=&bust_cache=&type=b&lastndays=7&dates=fromandto&fromandto=", t1, ".", t2, "&level=mlb&franch=&stat=&stat_value=0"))
       df <- payload |>
         rvest::html_elements(xpath = '//*[@id="daily"]') |>
         rvest::html_table(fill = TRUE)
@@ -71,16 +72,14 @@ bref_daily_batter <- function(t1, t2) {
       df <- df |> 
         dplyr::filter(.data$Name != "Name")
       
-      playerids <- payload |>
-        rvest::html_elements("table") |>
+      slugs <- payload |>
+        rvest::html_elements(xpath = '//*[@id="daily"]') |>
         rvest::html_elements("a") |>
-        rvest::html_attr("href") |>
-        as.data.frame() |>
-        dplyr::rename(slug = ".") |>
-        dplyr::filter(grepl("players", .data$slug)) |>
-        dplyr::mutate(playerid = gsub("/players/gl.fcgi\\?id=",
-                                  "", .data$slug)) |>
-        dplyr::mutate(playerid = gsub("&t.*","",.data$playerid))
+        rvest::html_attr("href")
+      slugs <- slugs[grepl("players", slugs)]
+      playerids <- data.frame(slug = slugs, stringsAsFactors = FALSE)
+      playerids$playerid <- gsub("/players/gl.fcgi?id=", "", playerids$slug, fixed = TRUE)
+      playerids$playerid <- gsub("&t.*", "", playerids$playerid)
       
       df <- df |>
         dplyr::mutate(bbref_id = playerids$playerid) |>

--- a/R/bref_daily_pitcher.R
+++ b/R/bref_daily_pitcher.R
@@ -8,6 +8,7 @@
 #'
 #'  |col_name |types     |description                                              |
 #'  |:--------|:---------|:--------------------------------------------------------|
+#'  |bbref_id |character |Baseball-Reference player id (slug).                     |
 #'  |season   |integer   |Season year.                                             |
 #'  |Name     |character |Player name.                                             |
 #'  |Age      |numeric   |Player age during the season.                            |
@@ -68,7 +69,7 @@ bref_daily_pitcher <- function(t1, t2) {
   df <- NULL
   tryCatch(
     expr = {
-      payload <- paste0("http://www.baseball-reference.com/leagues/daily.cgi?user_team=&bust_cache=&type=p&lastndays=7&dates=fromandto&fromandto=", t1, ".", t2, "&level=mlb&franch=&stat=&stat_value=0") |> 
+      payload <- paste0("https://www.baseball-reference.com/leagues/daily.cgi?user_team=&bust_cache=&type=p&lastndays=7&dates=fromandto&fromandto=", t1, ".", t2, "&level=mlb&franch=&stat=&stat_value=0") |> 
         xml2::read_html()
       
       df <- payload |>
@@ -112,16 +113,14 @@ bref_daily_pitcher <- function(t1, t2) {
       df <- df |> 
         dplyr::filter(.data$Name != "Name")
       
-      playerids <- payload |>
-        rvest::html_elements("table") |>
+      slugs <- payload |>
+        rvest::html_elements(xpath = '//*[@id="daily"]') |>
         rvest::html_elements("a") |>
-        rvest::html_attr("href") |>
-        as.data.frame() |>
-        dplyr::rename(slug = ".") |>
-        dplyr::filter(grepl("players", .data$slug)) |>
-        dplyr::mutate(playerid = gsub("/players/gl.fcgi\\?id=",
-                                      "", .data$slug)) |> 
-        dplyr::mutate(playerid = gsub("&t.*","",.data$playerid))
+        rvest::html_attr("href")
+      slugs <- slugs[grepl("players", slugs)]
+      playerids <- data.frame(slug = slugs, stringsAsFactors = FALSE)
+      playerids$playerid <- gsub("/players/gl.fcgi?id=", "", playerids$slug, fixed = TRUE)
+      playerids$playerid <- gsub("&t.*", "", playerids$playerid)
       
       df <- df |>
         dplyr::mutate(bbref_id = playerids$playerid) |>

--- a/R/bref_standings_on_date.R
+++ b/R/bref_standings_on_date.R
@@ -34,7 +34,7 @@ bref_standings_on_date <- function(date, division, from = FALSE) {
     stop("Please select a division in the following: \n'AL East', 'AL Central', 'AL West', 'AL Overall',\n'NL Central', 'NL West', 'NL Overall'")
   }
   
-  url <- paste0("http://www.baseball-reference.com/boxes",
+  url <- paste0("https://www.baseball-reference.com/boxes",
                 "?year=", sprintf("%04i", lubridate::year(date)), "&month=",
                 sprintf("%02i", lubridate::month(date)), "&day=", sprintf("%02i",
                                                                           lubridate::day(date)))

--- a/R/bref_team_results.R
+++ b/R/bref_team_results.R
@@ -24,6 +24,12 @@
 #'  |Loss     |character |Losing pitcher.                                          |
 #'  |Save     |character |Pitcher credited with the save (N if none).              |
 #'  |Time     |character |Duration of the game.                                    |
+#'  |D/N      |character |Day (D) or night (N) game.                               |
+#'  |Attendance |numeric |Announced attendance.                                    |
+#'  |cLI      |numeric   |Championship leverage index of the game.                 |
+#'  |Streak   |character |Win/loss streak entering the game.                       |
+#'  |Orig_Scheduled |character |Original scheduled date (for rescheduled games).   |
+#'  |Year     |numeric   |Season year.                                             |
 #'
 #' @importFrom dplyr filter select mutate_at
 #' @import rvest 
@@ -49,10 +55,8 @@ bref_team_results <- function(Tm, year) {
     expr = {
       data <- url |> 
         xml2::read_html() |>
-        rvest::html_elements("table")
-      
-      data <- data[[length(data)]] |>
-        rvest::html_table() 
+        rvest::html_element("#team_schedule") |>
+        rvest::html_table()
       data <- data[-3]
       
       col_names <- c('Gm','Date','Tm','H_A','Opp','Result','R','RA','Inn','Record','Rank',

--- a/R/metrics_team_consistency.R
+++ b/R/metrics_team_consistency.R
@@ -23,7 +23,7 @@ team_consistency <- function(year) {
   
   teams_data <- baseballr::teams_lu_table
   
-  url <- paste0("http://www.baseball-reference.com/leagues/MLB/",year,".shtml")
+  url <- paste0("https://www.baseball-reference.com/leagues/MLB/",year,".shtml")
 
   teams <- (url |> 
               xml2::read_html() |> 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -266,15 +266,6 @@ reference:
     contents:
       - '`spotrac`'
       - starts_with("sptrc")
-  - title: ESPN MLB
-  - subtitle: ESPN MLB Data Functions
-    desc: >
-      Functions exported by baseballr to access ESPN's Major League Baseball
-      endpoints (scoreboard, schedule, game summary / play-by-play, box scores,
-      teams, rosters, standings, athletes, leaders, draft, and reference data).
-    contents:
-      - '`espn_mlb`'
-      - starts_with("espn_mlb")
   - title: MLB Stats - Overview
     contents:
       - '`mlb`'
@@ -363,6 +354,15 @@ reference:
     desc: Functions exported by baseballr to access MLB Stats - Jobs Data
     contents:
       - starts_with("mlb_job")
+  - title: ESPN MLB
+  - subtitle: ESPN MLB Data Functions
+    desc: >
+      Functions exported by baseballr to access ESPN's Major League Baseball
+      endpoints (scoreboard, schedule, game summary / play-by-play, box scores,
+      teams, rosters, standings, athletes, leaders, draft, and reference data).
+    contents:
+      - '`espn_mlb`'
+      - starts_with("espn_mlb")
   - title: Metrics
   - subtitle: Metrics Functions
     desc: Functions exported by baseballr to calculate metrics

--- a/man/bref_daily_batter.Rd
+++ b/man/bref_daily_batter.Rd
@@ -14,6 +14,7 @@ bref_daily_batter(t1, t2)
 \value{
 Returns a tibble of batter performance over the requested date range, one row per player, with the following columns:\tabular{lll}{
    col_name \tab types \tab description \cr
+   bbref_id \tab character \tab Baseball-Reference player id (slug). \cr
    season \tab integer \tab Season year. \cr
    Name \tab character \tab Player name. \cr
    Age \tab numeric \tab Player age during the season. \cr

--- a/man/bref_daily_pitcher.Rd
+++ b/man/bref_daily_pitcher.Rd
@@ -14,6 +14,7 @@ bref_daily_pitcher(t1, t2)
 \value{
 Returns a tibble of pitcher performance over the requested date range, one row per player, with the following columns:\tabular{lll}{
    col_name \tab types \tab description \cr
+   bbref_id \tab character \tab Baseball-Reference player id (slug). \cr
    season \tab integer \tab Season year. \cr
    Name \tab character \tab Player name. \cr
    Age \tab numeric \tab Player age during the season. \cr

--- a/man/bref_team_results.Rd
+++ b/man/bref_team_results.Rd
@@ -30,6 +30,12 @@ Returns a tibble of MLB team results, one row per game on the team's schedule, w
    Loss \tab character \tab Losing pitcher. \cr
    Save \tab character \tab Pitcher credited with the save (N if none). \cr
    Time \tab character \tab Duration of the game. \cr
+   D/N \tab character \tab Day (D) or night (N) game. \cr
+   Attendance \tab numeric \tab Announced attendance. \cr
+   cLI \tab numeric \tab Championship leverage index of the game. \cr
+   Streak \tab character \tab Win/loss streak entering the game. \cr
+   Orig_Scheduled \tab character \tab Original scheduled date (for rescheduled games). \cr
+   Year \tab numeric \tab Season year. \cr
 }
 }
 \description{


### PR DESCRIPTION
# Pull Request

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Pull Request](#pull-request)
  - [Summary](#summary)
  - [Type of Change](#type-of-change)
  - [Related Issues](#related-issues)
  - [Background & Context](#background--context)
  - [Changes Made](#changes-made)
  - [Submission Checklist](#submission-checklist)
  - [Testing](#testing)
  - [Screenshots / Output](#screenshots--output)
  - [Reviewer Checklist](#reviewer-checklist)
  - [Additional Notes](#additional-notes)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

## Summary

Repairs the Baseball Reference (`bref_*`) scrapers, which had broken against the
current `baseball-reference.com` page/table structure, and reorders the pkgdown
reference index so the MLB Stats API functions are listed before the ESPN MLB
functions.

## Type of Change

- [ ] `feat`
- [x] `fix` -- Baseball Reference scrapers repaired
- [x] `docs` -- restored/added `@return` columns; pkgdown reference ordering
- [ ] `test`
- [ ] `refactor`
- [ ] `chore`
- [ ] `perf`

## Related Issues

- Baseball Reference scraping breakages (BBRef site/table-structure changes after
  the 2.0.0 release).

## Background & Context

Affected source: **Baseball Reference** (`baseball-reference.com`). BBRef did not
start blocking the default client (pages return HTTP 200) -- the breakages were
all in parsing against changed page structure:

- **`bref_team_results()`** grabbed `data[[length(data)]]` (the last `<table>` on
  the page). For teams that made the playoffs BBRef now appends a second table
  (`#team_schedule_post`, ~14 rows), so the function returned the postseason mini
  table instead of the full season, and then errored on a length-mismatched
  `names()<-` / a removed `Attendance` column.
- **`bref_daily_batter()` / `bref_daily_pitcher()`** failed at the player-id step:
  `... |> html_attr("href") |> as.data.frame() |> dplyr::rename(slug = ".")`
  relied on `as.data.frame()` naming the column `"."`, which modern R no longer
  does -- so the `rename()` threw and `bbref_id` was dropped from the output.
- Several functions fetched over `http://`.

## Changes Made

| File / Function | Change |
| --------------- | ------ |
| `R/bref_team_results.R` | Select the schedule table by id (`#team_schedule`) instead of the last table on the page, so playoff teams' postseason table is no longer picked up. Returns the full regular season again (e.g. 162 x 22). Documented the additional returned columns (`D/N`, `Attendance`, `cLI`, `Streak`, `Orig_Scheduled`, `Year`). |
| `R/bref_daily_batter.R`, `R/bref_daily_pitcher.R` | Build the player-id frame with an explicit column name scoped to the `#daily` table (replacing `as.data.frame() |> rename(slug = ".")`), use `gsub(..., fixed = TRUE)` for the literal id slug, and request over `https`. Restored `bbref_id` to the output and to the `@return` table. |
| `R/bref_standings_on_date.R` | Request over `https`. |
| `R/metrics_team_consistency.R` | Request over `https`; also fixed transitively via the `bref_team_results()` repair it depends on. |
| `_pkgdown.yml` | Move the **ESPN MLB** reference section to after the **MLB Stats - \*** sections so MLB Stats functions list first. |

## Submission Checklist

- [x] Code follows tidyverse style and the conventions in `CLAUDE.md`.
- [x] Ran `devtools::document()` and committed the regenerated `man/`.
- [x] Roxygen `@return` tables reflect the actual current output (incl. `bbref_id`).
- [x] `pkgdown::check_pkgdown()` passes (reference index valid after reorder).
- [x] No CRAN-relevant dependency or `Depends` change.

## Testing

Live-verified each function (Baseball Reference returns HTTP 200; these are
gated by `BREF_TESTS=1` in CI):

```
bref_team_results("NYY", 2024)              -> 162 x 22  (was 14 x 16 postseason)
bref_daily_batter("2024-05-01","2024-05-07")-> 411 x 30  (bbref_id restored)
bref_daily_pitcher("2024-05-01","2024-05-07")-> 419 x 46  (bbref_id restored)
bref_standings_on_date("2024-08-01","AL East") -> 5 x 8
team_consistency: first-table parse verified (32 teams) + delegates to fixed bref_team_results()
```

Execution time before: n/a
Execution time after:  n/a

## Screenshots / Output

```
> bref_team_results("NYY", 2024)
# 162 x 22: Gm, Date, Tm, H_A, Opp, Result, R, RA, ... , Attendance, cLI, Streak, Orig_Scheduled, Year

> head(names(bref_daily_batter("2024-05-01","2024-05-07")))
[1] "bbref_id" "season" "Name" "Age" "Level" "Team"
```

## Reviewer Checklist

- [ ] Function naming uses the correct data-source prefix.
- [ ] Return value is initialized before `tryCatch`; error path degrades gracefully.
- [ ] `man/` regenerated and consistent with the source.
- [ ] Tests appropriately gated.
- [ ] Commit messages are conventional and free of AI co-author trailers.

## Additional Notes

Builds on `master` post-2.0.0. The pkgdown change is index-ordering only (no
functions added or removed).
